### PR TITLE
fix(renderer): resize when map is resized

### DIFF
--- a/src/Threebox.js
+++ b/src/Threebox.js
@@ -550,6 +550,9 @@ Threebox.prototype = {
 
 		});
 
+		this.map.on('resize', () => {
+			this.renderer.setSize(this.map.getCanvas().clientWidth, this.map.getCanvas().clientHeight)
+		});
 	},
 
 	//[jscastro] added property to manage an athmospheric sky layer


### PR DESCRIPTION
Is set initially on line 64 but never updated. `src/objects/LabelRenderer.js` has something similar but already listens to the map resize event.