### PR TITLE
fix(camera): sync issue

### DIFF
--- a/src/camera/CameraSync.js
+++ b/src/camera/CameraSync.js
@@ -32,6 +32,9 @@ function CameraSync(map, camera, world) {
         .on('move', function () {
             _this.updateCamera();
         })
+        .on('moveend', function () {
+            _this.updateCamera()
+        })
         .on('resize', function () {
             _this.setupCamera();
         })
@@ -90,7 +93,7 @@ CameraSync.prototype = {
             // Furthest distance optimized by @jscastro76
             const topHalfSurfaceDistance = Math.sin(this.halfFov) * this.cameraToCenterDistance / Math.sin(Math.PI - groundAngle - this.halfFov);
 
-            // Calculate z distance of the farthest fragment that should be rendered. 
+            // Calculate z distance of the farthest fragment that should be rendered.
             furthestDistance = pitchAngle * topHalfSurfaceDistance + this.cameraToCenterDistance;
 
             // Add a bit extra to avoid precision problems when a fragment's distance is exactly `furthestDistance`
@@ -120,7 +123,7 @@ CameraSync.prototype = {
         if (t.elevation) cameraWorldMatrix.elements[14] = t._camera.position[2] * worldSize;
         //this.camera.matrixWorld.elements is equivalent to t._camera._transform
         this.camera.matrixWorld.copy(cameraWorldMatrix);
-        
+
         let zoomPow = t.scale * this.state.worldSizeRatio;
         // Handle scaling and translation of objects in the map in the world's matrix transform, not the camera
         let scale = new THREE.Matrix4;


### PR DESCRIPTION
It seems like updateCamera() is occasionally run with a with a camera transformation value (map.transform) that cause the models to appear under the terrain layer. I don't know why this is, possibly a timing issue within mapbox? Updating the camera at the end of a move seems to ensure that they reappear. Not perfect as the models will still jitter and clip strangely while moving the camera but hopefully they will no longer be left in a broken state when the camera stops moving.